### PR TITLE
Fix deprecation warning for TEMP_CELSIUS

### DIFF
--- a/custom_components/ojmicroline_thermostat/climate.py
+++ b/custom_components/ojmicroline_thermostat/climate.py
@@ -16,7 +16,7 @@ from homeassistant.components.climate.const import (
     PRESET_NONE,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -99,7 +99,7 @@ class OJMicrolineThermostat(
     _attr_supported_features = (
         ClimateEntityFeature.PRESET_MODE | ClimateEntityFeature.TARGET_TEMPERATURE
     )
-    _attr_temperature_unit = TEMP_CELSIUS
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
     _attr_has_entity_name = True
     _attr_name = None
 


### PR DESCRIPTION
### What does it do?
Replace with UnitOfTemperature