### PR TITLE
Refactor thermostat modes & actions

### DIFF
--- a/custom_components/ojmicroline_thermostat/const.py
+++ b/custom_components/ojmicroline_thermostat/const.py
@@ -16,8 +16,10 @@ CONF_COMFORT_MODE_DURATION = "comfort_mode_duration"
 MODEL_WD5_SERIES = "WD5 series"
 MODEL_WG4_SERIES = "WG4 series"
 
-PRESET_VACATION = "Vacation"
-PRESET_FROST_PROTECTION = "Frost Protection"
+PRESET_SCHEDULE = "schedule"
+PRESET_MANUAL = "manual"
+PRESET_VACATION = "vacation"
+PRESET_FROST_PROTECTION = "frost_protection"
 
 MODE_FLOOR = "Floor"
 MODE_ROOM = "Room"

--- a/custom_components/ojmicroline_thermostat/icons.json
+++ b/custom_components/ojmicroline_thermostat/icons.json
@@ -1,0 +1,21 @@
+{
+    "entity": {
+        "climate": {
+            "ojthermostat": {
+                "state_attributes": {
+                    "preset_mode": {
+                        "state": {
+                            "schedule": "mdi:clock-outline",
+                            "manual": "mdi:thermometer",
+                            "vacation": "mdi:umbrella-beach",
+                            "frost_protection": "mdi:snowflake",
+                            "boost": "mdi:rocket-launch",
+                            "comfort": "mdi:sofa",
+                            "eco": "mdi:leaf"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/custom_components/ojmicroline_thermostat/strings.json
+++ b/custom_components/ojmicroline_thermostat/strings.json
@@ -45,6 +45,22 @@
             "already_configured": "Your credentials are already configured."
         }
     },
+    "entity": {
+        "climate": {
+            "ojthermostat": {
+                "state_attributes": {
+                    "preset_mode": {
+                        "state": {
+                            "schedule": "Schedule",
+                            "manual": "Manual",
+                            "vacation": "Vacation",
+                            "frost_protection": "Frost Protection"
+                        }
+                    }
+                }
+            }
+        }
+    },
     "options": {
         "step": {
             "init": {

--- a/custom_components/ojmicroline_thermostat/translations/en.json
+++ b/custom_components/ojmicroline_thermostat/translations/en.json
@@ -45,6 +45,22 @@
             "already_configured": "Your credentials are already configured."
         }
     },
+    "entity": {
+        "climate": {
+            "ojthermostat": {
+                "state_attributes": {
+                    "preset_mode": {
+                        "state": {
+                            "schedule": "Schedule",
+                            "manual": "Manual",
+                            "vacation": "Vacation",
+                            "frost_protection": "Frost Protection"
+                        }
+                    }
+                }
+            }
+        }
+    },
     "options": {
         "step": {
             "init": {


### PR DESCRIPTION
This makes a few changes to better match how other thermostat entities work in Home Assistant:

**Whether the thermostat is heating or not is reflected via `HVACAction` not `HVACMode`.** Thermostats now only have a single mode, `HEAT`, since OJ Microline thermostats can only heat and cannot be turned off via the API. I think this better matches the intended design, where the "action" is whatever the thermostat is choosing to do at a moment in time and the "mode" is a user-changeable item.

**Presets updated.** Instead of the built-in preset "Home", use a custom preset "Schedule". Instead of the built-in preset "None", use a custom preset "Manual". For all presets, use the new [Icon Translations](https://developers.home-assistant.io/blog/2024/01/19/icon-translations/) feature to give them sensible icons.

<img width="252" alt="Screen Shot 2024-02-12 at 10 04 04 AM" src="https://github.com/robbinjanssen/home-assistant-ojmicroline-thermostat/assets/97944/773ac214-60e2-4767-a829-a2da2c0299a9">

**Fix min/max temps.** We wanted e.g. `max_temp` not `target_temperature_high` — the latter is for target temperature ranges, which these thermostats do not support anyway.