### PR TITLE
Make the WG4 login Application code configurable (Danfoss LX)

### DIFF
--- a/custom_components/ojmicroline_thermostat/api.py
+++ b/custom_components/ojmicroline_thermostat/api.py
@@ -8,7 +8,14 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from ojmicroline_thermostat import WD5API, WG4API, OJMicroline
 
-from .const import CONF_CUSTOMER_ID, CONF_MODEL, MODEL_WD5_SERIES, MODEL_WG4_SERIES
+from .const import (
+    CONF_APPLICATION,
+    CONF_CUSTOMER_ID,
+    CONF_MODEL,
+    DEFAULT_WG4_APPLICATION,
+    MODEL_WD5_SERIES,
+    MODEL_WG4_SERIES,
+)
 
 
 def oj_microline_from_config_entry_data(
@@ -41,6 +48,7 @@ def _api_from_config_entry_data(data: dict[str, Any]) -> Any:
         return WG4API(
             username=data[CONF_USERNAME],
             password=data[CONF_PASSWORD],
+            application=data.get(CONF_APPLICATION, DEFAULT_WG4_APPLICATION),
             **extra_args,
         )
     msg = f"Unknown model {model}"

--- a/custom_components/ojmicroline_thermostat/config_flow.py
+++ b/custom_components/ojmicroline_thermostat/config_flow.py
@@ -18,11 +18,13 @@ from ojmicroline_thermostat.const import COMFORT_DURATION
 
 from .api import oj_microline_from_config_entry_data
 from .const import (
+    CONF_APPLICATION,
     CONF_COMFORT_MODE_DURATION,
     CONF_CUSTOMER_ID,
     CONF_MODEL,
     CONF_USE_COMFORT_MODE,
     CONFIG_FLOW_VERSION,
+    DEFAULT_WG4_APPLICATION,
     DOMAIN,
     INTEGRATION_NAME,
     MODEL_WD5_SERIES,
@@ -37,6 +39,7 @@ DATA_SCHEMA = vol.Schema(
         CONF_HOST: str,
         CONF_CUSTOMER_ID: int,
         CONF_API_KEY: str,
+        vol.Optional(CONF_APPLICATION): int,
     }
 )
 
@@ -61,6 +64,7 @@ WG4_STEP_SCHEMA = vol.Schema(
         vol.Required(CONF_USERNAME): str,
         vol.Required(CONF_PASSWORD): str,
         CONF_HOST: str,
+        vol.Optional(CONF_APPLICATION, default=DEFAULT_WG4_APPLICATION): int,
     }
 )
 

--- a/custom_components/ojmicroline_thermostat/const.py
+++ b/custom_components/ojmicroline_thermostat/const.py
@@ -10,11 +10,16 @@ UPDATE_INTERVAL = 60
 
 CONF_MODEL = "model"
 CONF_CUSTOMER_ID = "customer_id"
+CONF_APPLICATION = "application"
 CONF_USE_COMFORT_MODE = "use_comfort_mode"
 CONF_COMFORT_MODE_DURATION = "comfort_mode_duration"
 
 MODEL_WD5_SERIES = "WD5 series"
 MODEL_WG4_SERIES = "WG4 series"
+
+# The application code sent on WG4 login. Standard WG4 thermostats use 2
+# (the library default); Danfoss LX (lxwifi.danfoss.us) requires 4.
+DEFAULT_WG4_APPLICATION = 2
 
 PRESET_SCHEDULE = "schedule"
 PRESET_MANUAL = "manual"

--- a/custom_components/ojmicroline_thermostat/manifest.json
+++ b/custom_components/ojmicroline_thermostat/manifest.json
@@ -10,7 +10,7 @@
     "iot_class": "cloud_polling",
     "issue_tracker": "https://github.com/robbinjanssen/home-assistant-ojmicroline-thermostat/issues",
     "requirements": [
-        "ojmicroline-thermostat==3.3.0"
+        "ojmicroline-thermostat==3.5.0"
     ],
     "version": "1.3.0"
 }

--- a/custom_components/ojmicroline_thermostat/strings.json
+++ b/custom_components/ojmicroline_thermostat/strings.json
@@ -28,10 +28,12 @@
                 "data": {
                     "username": "Username",
                     "password": "Password",
-                    "host": "Host"
+                    "host": "Host",
+                    "application": "Application code"
                 },
                 "data_description": {
-                    "host": "Leave blank to use the default. If specified, omit the https://."
+                    "host": "Leave blank to use the default. If specified, omit the https://.",
+                    "application": "The application code sent on login. Standard WG4 thermostats use 2 (the default); Danfoss LX (lxwifi.danfoss.us) requires 4."
                 }
             }
         },

--- a/custom_components/ojmicroline_thermostat/translations/en.json
+++ b/custom_components/ojmicroline_thermostat/translations/en.json
@@ -28,10 +28,12 @@
                 "data": {
                     "username": "Username",
                     "password": "Password",
-                    "host": "Host"
+                    "host": "Host",
+                    "application": "Application code"
                 },
                 "data_description": {
-                    "host": "Leave blank to use the default. If specified, omit the https://."
+                    "host": "Leave blank to use the default. If specified, omit the https://.",
+                    "application": "The application code sent on login. Standard WG4 thermostats use 2 (the default); Danfoss LX (lxwifi.danfoss.us) requires 4."
                 }
             }
         },


### PR DESCRIPTION
Fixes #441.

## Problem
The WG4 login sends a hardcoded `Application=2`. Danfoss LX accounts (`lxwifi.danfoss.us`) authenticate with `Application=4`, so those users log in successfully but get an **empty device list** — no thermostats appear.

## Fix
The library side already landed in [robbinjanssen/python-ojmicroline-thermostat#687](https://github.com/robbinjanssen/python-ojmicroline-thermostat/pull/687), released in **`ojmicroline-thermostat` 3.5.0**, which makes the WG4 `application` code a constructor argument (default `2`). This PR surfaces it in the integration:

- Bump the library requirement `3.3.0` → `3.5.0`.
- Add an optional **Application code** field to the WG4 config step (default `2`; set `4` for Danfoss LX) and thread it through `DATA_SCHEMA`.
- Pass `application` to `WG4API` when constructing the client.
- Add `strings.json` / `translations/en.json` entries describing the field.

WD5 is unaffected (the field only appears in the WG4 step; `DATA_SCHEMA` treats it as optional).

## Notes
- Default stays `2`, so existing WG4 users see no behavior change.
- `3.5.0` is published on PyPI.
- Verified: config-flow schema validation accepts WG4 with/without `application` and WD5 without it; JSON + `py_compile` clean; no new `ruff` findings.

## Test plan
- Existing WG4 (non-LX): leave Application at `2` → unchanged.
- Danfoss LX: host `lxwifi.danfoss.us`, Application `4` → thermostats now load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)